### PR TITLE
[JEP-12] JSON string literals are deprecated.

### DIFF
--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -1,5 +1,5 @@
 import { JSONValue } from './JSON.type';
-import { LexerToken, Token } from './Lexer.type';
+import { LexerOptions, LexerToken, Token } from './Lexer.type';
 import { isAlpha, isNum, isAlphaNum } from './utils/index';
 
 export const basicTokens: Record<string, Token> = {
@@ -39,10 +39,13 @@ const skipChars: Record<string, boolean> = {
 };
 
 class StreamLexer {
-  _current = 0;
-  tokenize(stream: string): LexerToken[] {
+  private _current = 0;
+  private _enable_legacy_literals = false;
+
+  tokenize(stream: string, options?: LexerOptions): LexerToken[] {
     const tokens: LexerToken[] = [];
     this._current = 0;
+    this._enable_legacy_literals = options?.enable_legacy_literals || false;
 
     let start;
     let identifier;
@@ -239,11 +242,31 @@ class StreamLexer {
       }
       this._current = current;
     }
-    let literalString = stream.slice(start, this._current).trimLeft();
+    let literalString = stream.slice(start, this._current).trimStart();
     literalString = literalString.replace('\\`', '`');
-    const literal: JSONValue = this.looksLikeJSON(literalString)
-      ? (JSON.parse(literalString) as JSONValue)
-      : (JSON.parse(`"${literalString}"`) as string);
+
+    let literal: JSONValue = null;
+    let ok = false;
+
+    // attempts to detect and parse valid JSON
+
+    if (this.looksLikeJSON(literalString)) {
+      [literal, ok] = this.parseJSON(literalString);
+    }
+
+    // invalid JSON values should be converted to quoted
+    // JSON strings during the JEP-12 deprecation period.
+
+    if (!ok && this._enable_legacy_literals) {
+      [literal, ok] = this.parseJSON(`"${literalString}"`);
+    }
+
+    if (!ok) {
+      const error = new Error(`Syntax: unexpected end of JSON input or invalid format for a JSON literal: ${stream[this._current]}`);
+      error.name = 'LexerError';
+      throw error;
+    }
+
     this._current += 1;
     return literal;
   }
@@ -263,15 +286,21 @@ class StreamLexer {
       return true;
     }
     if (numberLooking.includes(literalString[0])) {
-      try {
-        JSON.parse(literalString);
-        return true;
-      } catch {
-        return false;
-      }
+      const [_, ok] = this.parseJSON(literalString);
+      return ok;
     }
     return false;
   }
+
+  private parseJSON(text: string): [JSONValue, boolean]{
+    try {
+      const json = JSON.parse(text);
+      return [json, true];
+    } catch {
+      return [null, false];
+    }
+  }
+
 }
 
 export const Lexer = new StreamLexer();

--- a/src/Lexer.type.ts
+++ b/src/Lexer.type.ts
@@ -46,3 +46,13 @@ export interface LexerToken {
   value: LexerTokenValue;
   start: number;
 }
+
+export interface LexerOptions {
+  // The flag to enable pre-JEP-12 literal compatibility.
+  // JEP-12 deprecates `foo` -> "foo" syntax.
+  // Valid expressions MUST use: `"foo"` -> "foo"
+  //
+  // Setting this flag to `true` enables support for legacy syntax.
+  //
+  enable_legacy_literals?: boolean;
+}

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -14,6 +14,7 @@ import type {
 } from './AST.type';
 import Lexer from './Lexer';
 import { LexerToken, Token } from './Lexer.type';
+import { Options } from './Parser.type';
 
 const bindingPower: Record<string, number> = {
   [Token.TOK_EOF]: 0,
@@ -55,9 +56,11 @@ const bindingPower: Record<string, number> = {
 class TokenParser {
   index = 0;
   tokens: LexerToken[] = [];
-  parse(expression: string): ExpressionNode {
-    this.loadTokens(expression);
+
+  parse(expression: string, options?: Options): ExpressionNode {
+    this.loadTokens(expression, options || { enable_legacy_literals: false, });
     this.index = 0;
+
     const ast = this.expression(0);
     if (this.lookahead(0) !== Token.TOK_EOF) {
       const token = this.lookaheadToken(0);
@@ -66,8 +69,8 @@ class TokenParser {
     return ast;
   }
 
-  private loadTokens(expression: string): void {
-    this.tokens = [...Lexer.tokenize(expression), { type: Token.TOK_EOF, value: '', start: expression.length }];
+  private loadTokens(expression: string, options: Options): void {
+    this.tokens = [...Lexer.tokenize(expression, options), { type: Token.TOK_EOF, value: '', start: expression.length }];
   }
 
   expression(rbp: number): ExpressionNode {

--- a/src/Parser.type.ts
+++ b/src/Parser.type.ts
@@ -1,0 +1,3 @@
+import { LexerOptions } from "./Lexer.type";
+
+export type Options = LexerOptions;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,15 @@
 import Parser from './Parser';
 import Lexer from './Lexer';
+import TreeInterpreterInst from './TreeInterpreter';
 
 import { ExpressionNode } from './AST.type';
 import { JSONValue } from './JSON.type';
-import { LexerToken } from './Lexer.type';
-import TreeInterpreterInst from './TreeInterpreter';
+import { LexerOptions, LexerToken } from './Lexer.type';
+import { Options } from './Parser.type';
 import { InputArgument, RuntimeFunction, InputSignature } from './Runtime';
 import { ScopeChain } from './Scope';
 
+export type { Options } from './Parser.type';
 export type { FunctionSignature, RuntimeFunction, InputSignature } from './Runtime';
 
 export const TYPE_ANY = InputArgument.TYPE_ANY;
@@ -23,13 +25,13 @@ export const TYPE_NUMBER = InputArgument.TYPE_NUMBER;
 export const TYPE_OBJECT = InputArgument.TYPE_OBJECT;
 export const TYPE_STRING = InputArgument.TYPE_STRING;
 
-export function compile(expression: string): ExpressionNode {
-  const nodeTree = Parser.parse(expression);
+export function compile(expression: string, options?: Options): ExpressionNode {
+  const nodeTree = Parser.parse(expression, options);
   return nodeTree;
 }
 
-export function tokenize(expression: string): LexerToken[] {
-  return Lexer.tokenize(expression);
+export function tokenize(expression: string, options?: LexerOptions): LexerToken[] {
+  return Lexer.tokenize(expression, options);
 }
 
 export const registerFunction = (
@@ -41,8 +43,8 @@ export const registerFunction = (
   TreeInterpreterInst.runtime.registerFunction(functionName, customFunction, signature);
 };
 
-export function search(data: JSONValue, expression: string): JSONValue {
-  const nodeTree = Parser.parse(expression);
+export function search(data: JSONValue, expression: string, options?: Options): JSONValue {
+  const nodeTree = Parser.parse(expression, options);
   return TreeInterpreterInst.search(nodeTree, data);
 }
 

--- a/test/compliance/jep-12/jep-12-literal.json
+++ b/test/compliance/jep-12/jep-12-literal.json
@@ -1,0 +1,39 @@
+[
+  {
+    "comment": "Literals",
+    "given": {
+      "type": "object"
+    },
+    "cases": [
+      {
+        "expression": "`foo`",
+        "error": "syntax"
+      },
+      {
+        "comment": "Literal with non-JSON whitespace U+0085 NEXT LINE",
+        "expression": "`0\u0085`",
+        "error": "syntax"
+      },
+      {
+        "comment": "Literal with non-JSON whitespace U+00A0 NO-BREAK SPACE",
+        "expression": "`0\u00A0`",
+        "error": "syntax"
+      },
+      {
+        "comment": "Literal with non-JSON whitespace U+1680 OGHAM SPACE MARK",
+        "expression": "`0\u1680`",
+        "error": "syntax"
+      },
+      {
+        "comment": "Literal with non-JSON whitespace U+2028 LINE SEPARATOR",
+        "expression": "`0\u2028`",
+        "error": "syntax"
+      },
+      {
+        "comment": "Literal with non-JSON whitespace U+3000 IDEOGRAPHIC SPACE",
+        "expression": "`0\u3000`",
+        "error": "syntax"
+      }
+    ]
+  }
+]

--- a/test/compliance/legacy/legacy-literal.json
+++ b/test/compliance/legacy/legacy-literal.json
@@ -1,0 +1,89 @@
+[
+  {
+    "given": {
+      "foo": [
+        {
+          "name": "a"
+        },
+        {
+          "name": "b"
+        }
+      ],
+      "bar": {
+        "baz": "qux"
+      }
+    },
+    "cases": [
+      {
+        "expression": "`foo`",
+        "result": "foo"
+      },
+      {
+        "comment": "Double quotes must be escaped.",
+        "expression": "`foo\\\"quote`",
+        "result": "foo\"quote"
+      },
+      {
+        "expression": "`✓`",
+        "result": "✓"
+      },
+      {
+        "expression": "`1\\``",
+        "result": "1`"
+      },
+      {
+        "comment": "Multiple literal expressions with escapes",
+        "expression": "`\\\\`.{a:`b`}",
+        "result": {
+          "a": "b"
+        }
+      }
+    ]
+  },
+  {
+    "comment": "Literals",
+    "given": {
+      "type": "object"
+    },
+    "cases": [
+      {
+        "expression": "`foo`",
+        "result": "foo"
+      },
+      {
+        "expression": "`      foo`",
+        "result": "foo"
+      },
+      {
+        "comment": "Literal on RHS of subexpr not allowed",
+        "expression": "foo.`bar`",
+        "error": "syntax"
+      },
+      {
+        "comment": "Literal with non-JSON whitespace U+0085 NEXT LINE",
+        "expression": "`0\u0085`",
+        "result": "0\u0085"
+      },
+      {
+        "comment": "Literal with non-JSON whitespace U+00A0 NO-BREAK SPACE",
+        "expression": "`0\u00A0`",
+        "result": "0\u00A0"
+      },
+      {
+        "comment": "Literal with non-JSON whitespace U+1680 OGHAM SPACE MARK",
+        "expression": "`0\u1680`",
+        "result": "0\u1680"
+      },
+      {
+        "comment": "Literal with non-JSON whitespace U+2028 LINE SEPARATOR",
+        "expression": "`0\u2028`",
+        "result": "0\u2028"
+      },
+      {
+        "comment": "Literal with non-JSON whitespace U+3000 IDEOGRAPHIC SPACE",
+        "expression": "`0\u3000`",
+        "result": "0\u3000"
+      }
+    ]
+  }
+]

--- a/test/jmespath-lexer.spec.ts
+++ b/test/jmespath-lexer.spec.ts
@@ -76,10 +76,10 @@ describe('tokenize', () => {
   it('should tokenize json literals', () => {
     expect(tokenize('`true`')).toMatchObject([{ type: 'Literal', value: true, start: 0 }]);
   });
-  it('should not requiring surrounding quotes for strings', () => {
-    expect(tokenize('`foo`')).toMatchObject([{ type: 'Literal', value: 'foo', start: 0 }]);
+  it('should not require surrounding quotes for strings', () => {
+    expect(tokenize('`foo`', { enable_legacy_literals: true })).toMatchObject([{ type: 'Literal', value: 'foo', start: 0 }]);
   });
-  it('should not requiring surrounding quotes for numbers', () => {
+  it('should not require surrounding quotes for numbers', () => {
     expect(tokenize('`20`')).toMatchObject([{ type: 'Literal', value: 20, start: 0 }]);
   });
   it('should tokenize literal lists with chars afterwards', () => {


### PR DESCRIPTION
By default, this library no longer accepts deprecated JSON string literals.
This PR adds an opt-in option that re-enables JSON string literals.