### PR TITLE
No longer supporting NodeJS 14.x

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x, 20.x, 22.x, 23.x]
 
     steps:
     - name: 📚 checkout
@@ -27,7 +27,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install ## ci is not enough on node 14.x
+    - run: npm install
     - run: npm run build --if-present
     - name: ☢ tests
       run: npm test


### PR DESCRIPTION
This pull request removes support for NodeJS `14.x` which no longer runs on modern versions of GitHub actions.

It also introduces support for latest NodeJS versions `18.x`, `20.x`, `22.x` and `23.x`.