### PR TITLE
fix(editorconfig): disable max_line_length property

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ indent_size = 2
 indent_style = space
 insert_final_newline = true
 # editorconfig-tools is unable to ignore longs strings or urls
-max_line_length = null
+max_line_length = off
 trim_trailing_whitespace = true
 
 [*.md]


### PR DESCRIPTION
Set the `max_line_length` property from `null` to `off`, aligning with EditorConfig specifications to disable line wrapping.

> Forces hard line wrapping after the amount of characters specified. `off` to turn off this feature (use the editor settings).

ref [max_line_length](https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#max_line_length)

<!-- ps-id: e0efbebf-3170-4ae7-a5b9-55a2765be229 -->