### PR TITLE
(fix) Fixed some lint warnings.

### DIFF
--- a/src/Runtime.ts
+++ b/src/Runtime.ts
@@ -46,11 +46,11 @@ export interface InputSignature {
   optional?: boolean;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type RuntimeFunction<T extends any[], U> = (resolvedArgs: T) => U;
+export type RuntimeFunction<T extends (JSONValue | ExpressionNode)[], U> = (resolvedArgs: T) => U;
 
 export interface FunctionSignature {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // biome-ignore lint: lint/suspicious/noExplicitAny
   _func: RuntimeFunction<any, JSONValue>;
   _signature: InputSignature[];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,8 +38,7 @@ export function tokenize(expression: string, options?: LexerOptions): LexerToken
 
 export const registerFunction = (
   functionName: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  customFunction: RuntimeFunction<any[], JSONValue>,
+  customFunction: RuntimeFunction<(JSONValue | ExpressionNode)[], JSONValue>,
   signature: InputSignature[],
 ): void => {
   TreeInterpreterInst.runtime.registerFunction(functionName, customFunction, signature);

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -41,6 +41,7 @@ export class Text {
 
   private get codePoints(): number[] {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    // biome-ignore lint: lint/style/noNonNullAssertion
     const array = [...this._text].map(s => s.codePointAt(0)!);
     return array;
   }


### PR DESCRIPTION
This pull request fixes some lint warnings by enforcing concrete types instead of using `any`.

It also uses the `// biome-ignore` comments in places where we cannot refactor the code.