### PR TITLE
feat(perf): improve lexer performance

### DIFF
--- a/scripts/perf.js
+++ b/scripts/perf.js
@@ -1,4 +1,4 @@
-const jmespath = require('../dist/lib');
+const jmespath = require('../dist/lib/src');
 const { Bench } = require('tinybench');
 
 async function runBenchmarks() {
@@ -14,6 +14,7 @@ async function runBenchmarks() {
     time: 1000,
   });
 
+  // Baseline parsing benchmarks
   bench
     .add('Parser#single_expr', () => {
       jmespath.compile('foo');
@@ -33,6 +34,16 @@ async function runBenchmarks() {
     })
     .add('Parser#basic_list_projection', () => {
       jmespath.compile('foo[*].bar');
+    })
+    // Additional lexer-heavy benchmarks
+    .add('Lexer#common_identifiers', () => {
+      jmespath.compile('foo.bar.baz.qux.foo.bar.baz.qux');
+    })
+    .add('Lexer#mixed_tokens', () => {
+      jmespath.compile('items[?price > `100`].name');
+    })
+    .add('Lexer#function_calls', () => {
+      jmespath.compile('sort_by(items, &price).name');
     });
 
   await bench.run();

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -76,10 +76,8 @@ class TokenParser {
   }
 
   private loadTokens(expression: string, options: Options): void {
-    this.tokens = [
-      ...Lexer.tokenize(expression, options),
-      { type: Token.TOK_EOF, value: '', start: expression.length },
-    ];
+    this.tokens = Lexer.tokenize(expression, options);
+    this.tokens.push({ type: Token.TOK_EOF, value: '', start: expression.length });
   }
 
   expression(rbp: number): ExpressionNode {


### PR DESCRIPTION
 - Replace object spread to improve performance of lexer
 - Direct assignment + push is better optimized by V8's JIT compiler

Before

```
┌─────────┬─────────────────────────────────┬──────────────┬────────────────────┬──────────┬──────────┐
│ (index) │ Task Name                       │ ops/sec      │ Average Time (ns)  │ Margin   │ Samples  │
├─────────┼─────────────────────────────────┼──────────────┼────────────────────┼──────────┼──────────┤
│ 0       │ 'Parser#single_expr'            │ '14,147,126' │ 70.68573011330783  │ '±0.70%' │ 14147127 │
│ 1       │ 'Parser#single_subexpr'         │ '6,499,427'  │ 153.85971442402027 │ '±0.58%' │ 6499428  │
│ 2       │ 'Parser#deeply_nested_50'       │ '323,190'    │ 3094.1537388112297 │ '±0.61%' │ 323191   │
│ 3       │ 'Parser#deeply_nested_50_index' │ '185,184'    │ 5400.025428624975  │ '±0.55%' │ 185185   │
│ 4       │ 'Parser#basic_list_projection'  │ '3,725,417'  │ 268.4262576707434  │ '±0.70%' │ 3725418  │
│ 5       │ 'Lexer#common_identifiers'      │ '1,628,946'  │ 613.8937718658917  │ '±0.46%' │ 1628947  │
│ 6       │ 'Lexer#mixed_tokens'            │ '1,639,320'  │ 610.008940897486   │ '±0.58%' │ 1639321  │
│ 7       │ 'Lexer#function_calls'          │ '2,283,372'  │ 437.948678117997   │ '±0.70%' │ 2283373  │
└─────────┴─────────────────────────────────┴──────────────┴────────────────────┴──────────┴──────────┘
```

After

```
┌─────────┬─────────────────────────────────┬──────────────┬────────────────────┬──────────┬──────────┐
│ (index) │ Task Name                       │ ops/sec      │ Average Time (ns)  │ Margin   │ Samples  │
├─────────┼─────────────────────────────────┼──────────────┼────────────────────┼──────────┼──────────┤
│ 0       │ 'Parser#single_expr'            │ '16,053,435' │ 62.29196192015425  │ '±0.45%' │ 16053436 │
│ 1       │ 'Parser#single_subexpr'         │ '7,385,154'  │ 135.40677954624348 │ '±0.49%' │ 7385155  │
│ 2       │ 'Parser#deeply_nested_50'       │ '322,845'    │ 3097.4563878751533 │ '±0.63%' │ 322846   │
│ 3       │ 'Parser#deeply_nested_50_index' │ '190,063'    │ 5261.401470032018  │ '±0.61%' │ 190064   │
│ 4       │ 'Parser#basic_list_projection'  │ '4,488,960'  │ 222.76873289856564 │ '±0.04%' │ 4488961  │
│ 5       │ 'Lexer#common_identifiers'      │ '1,764,451'  │ 566.748222111554   │ '±0.08%' │ 1764452  │
│ 6       │ 'Lexer#mixed_tokens'            │ '1,723,512'  │ 580.2105043600956  │ '±0.61%' │ 1723513  │
│ 7       │ 'Lexer#function_calls'          │ '2,560,641'  │ 390.5271908375201  │ '±0.29%' │ 2560642  │
└─────────┴─────────────────────────────────┴──────────────┴────────────────────┴──────────┴──────────┘
```

<!-- ps-id: 907c6ded-95d1-43aa-becd-a56c74c7b6f6 -->