### PR TITLE
perf: runtime function type checking overhead

### DIFF
--- a/src/Runtime.ts
+++ b/src/Runtime.ts
@@ -201,26 +201,28 @@ export class Runtime {
     return false;
   }
   private getTypeName(obj: JSONValue | ExpressionNode): InputArgument | undefined {
-    switch (Object.prototype.toString.call(obj)) {
-      case '[object String]':
-        return InputArgument.TYPE_STRING;
-      case '[object Number]':
-        return InputArgument.TYPE_NUMBER;
-      case '[object Array]':
-        return InputArgument.TYPE_ARRAY;
-      case '[object Boolean]':
-        return InputArgument.TYPE_BOOLEAN;
-      case '[object Null]':
-        return InputArgument.TYPE_NULL;
-      case '[object Object]':
-        if ((obj as ObjectDict).expref) {
-          return InputArgument.TYPE_EXPREF;
-        }
-        return InputArgument.TYPE_OBJECT;
-
-      default:
-        return;
+    if (obj === null) {
+      return InputArgument.TYPE_NULL;
     }
+    if (typeof obj === 'string') {
+      return InputArgument.TYPE_STRING;
+    }
+    if (typeof obj === 'number') {
+      return InputArgument.TYPE_NUMBER;
+    }
+    if (typeof obj === 'boolean') {
+      return InputArgument.TYPE_BOOLEAN;
+    }
+    if (Array.isArray(obj)) {
+      return InputArgument.TYPE_ARRAY;
+    }
+    if (typeof obj === 'object') {
+      if ((obj as ObjectDict).expref) {
+        return InputArgument.TYPE_EXPREF;
+      }
+      return InputArgument.TYPE_OBJECT;
+    }
+    return;
   }
 
   createKeyFunction(exprefNode: ExpressionNode, allowedTypes: InputArgument[]): (x: JSONValue) => JSONValue {


### PR DESCRIPTION
<!-- ps-id: fd3afb3d-774f-4fe5-8171-afc0c54be315 -->

Updates type checking calls for better performance - `Object.prototype.toString.call` is more expensive

Runtime#max_function: +18.6% improvement (343K → 407K ops/sec)
Runtime#sort_by_function: +16.7% improvement (225K → 263K ops/sec)
Runtime#length_function: +2.9% improvement (3.38M → 3.48M ops/sec)
Runtime#map_function: +1.1% improvement (522K → 528K ops/sec)
Runtime#contains_function: +1.1% improvement (437K → 442K ops/sec