### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: 🚀 release
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/jmespath-community/typescript-jmespath/security/code-scanning/10](https://github.com/jmespath-community/typescript-jmespath/security/code-scanning/10)

The fix involves adding a `permissions` block to explicitly limit the permissions of the `GITHUB_TOKEN`. This can be done either at the root of the workflow (applying to all jobs) or within each job. In this case, adding it at the root level is more efficient as both jobs do not appear to require elevated write permissions. Based on the provided workflow, the jobs only need to read repository contents and do not perform actions like creating issues or pushing code.

The permissions block will restrict access to:
- `contents: read`: Allowing only read access to repository content.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
