### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -2,6 +2,9 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: ☢ tests
+permissions:
+  contents: read
+  actions: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jmespath-community/typescript-jmespath/security/code-scanning/9](https://github.com/jmespath-community/typescript-jmespath/security/code-scanning/9)

To fix the issue, we need to add the `permissions` key at the root of the workflow. This will apply the permissions block to all jobs in the workflow unless overridden by individual job-level permissions. The permissions should be scoped to the least privileges required for the tasks in the workflow. Based on the tasks performed (checking out code, uploading artifacts), `contents: read` and `actions: write` are appropriate minimal permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
